### PR TITLE
Add new response code handling

### DIFF
--- a/xiloader/network.h
+++ b/xiloader/network.h
@@ -36,6 +36,19 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 
 namespace xiloader
 {
+    // In VerifyAccount - response codes to login attempts
+    enum class AccountResult
+    {
+        Login_Success = 0x001,
+        Login_Error = 0x002,
+        Create_Success = 0x003,
+        Create_Taken = 0x004,
+        Create_Disabled = 0x008,
+        Create_Error = 0x009,
+        PassChange_Request = 0x005,
+        PassChange_Success = 0x006,
+        PassChange_Error = 0x007,
+    };
     /**
      * @brief Socket object used to hold various important information.
      */


### PR DESCRIPTION
xiloader currently only has one account creation error code and reports all possible error situations as "Username is taken". This PR clarifies errors which occur during account creation, and makes handling of those response codes clearer.

This does not impact older versions of xiloader's ability to connect to new versions of Topaz, nor does it affect this new xiloader connecting to older versions of Topaz wherein the old error reporting messaging will still appear.

This is a prerequisite PR for https://github.com/project-topaz/topaz/pull/596.