### PR TITLE
Thread updates

### DIFF
--- a/xiloader/main.cpp
+++ b/xiloader/main.cpp
@@ -440,12 +440,12 @@ int __cdecl main(int argc, char* argv[])
             xiloader::network::CleanupSocket(sock.s, SD_SEND);
 
             /* Cleanup threads.. */
+            thead_polServer.join();
+            thread_ffxiServer.join();
             if (thread_ffxi.joinable())
             {
                 thread_ffxi.join();
             }
-            thead_polServer.join();
-            thread_ffxiServer.join();
         }
     }
     else

--- a/xiloader/main.cpp
+++ b/xiloader/main.cpp
@@ -26,21 +26,10 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "network.h"
 
 #include <thread>
-#include <mutex>
-#include <condition_variable>
 
 /* Global Variables */
-xiloader::Language g_Language = xiloader::Language::English; // The language of the loader to be used for polcore.
 std::string g_ServerAddress = "127.0.0.1"; // The server address to connect to.
-std::string g_ServerPort = "51220"; // The server lobby server port to connect to.
-std::string g_Username = ""; // The username being logged in with.
-std::string g_Password = ""; // The password being logged in with.
-char* g_CharacterList = NULL; // Pointer to the character list data being sent from the server.
-bool g_IsRunning = false; // Flag to determine if the network threads should hault.
 bool g_Hide = false; // Determines whether or not to hide the console window after FFXI starts.
-
-std::mutex g_mutex;
-std::condition_variable g_conditionVariable;
 
 /* Hairpin Fix Variables */
 DWORD g_NewServerAddress; // Hairpin server address to be overriden with.
@@ -151,11 +140,13 @@ hostent* __stdcall Mine_gethostbyname(const char* name)
 /**
  * @brief Locates the INET mutex function call inside of polcore.dll
  *
+ * @param language  POL language.
+ *
  * @return The pointer to the function call.
  */
-inline DWORD FindINETMutex(void)
+inline DWORD FindINETMutex(const xiloader::Language& language)
 {
-    const char* module = (g_Language == xiloader::Language::European) ? "polcoreeu.dll" : "polcore.dll";
+    const char* module = (language == xiloader::Language::European) ? "polcoreeu.dll" : "polcore.dll";
     auto result = (DWORD)xiloader::functions::FindPattern(module, (BYTE*)"\x8B\x56\x2C\x8B\x46\x28\x8B\x4E\x24\x52\x50\x51", "xxxxxxxxxxxx");
     return (*(DWORD*)(result - 4) + (result));
 }
@@ -163,11 +154,13 @@ inline DWORD FindINETMutex(void)
 /**
  * @brief Locates the PlayOnline connection object inside of polcore.dll
  *
+ * @param language  POL language.
+ *
  * @return Pointer to the pol connection object.
  */
-inline DWORD FindPolConn(void)
+inline DWORD FindPolConn(const xiloader::Language& language)
 {
-    const char* module = (g_Language == xiloader::Language::European) ? "polcoreeu.dll" : "polcore.dll";
+    const char* module = (language == xiloader::Language::European) ? "polcoreeu.dll" : "polcore.dll";
     auto result = (DWORD)xiloader::functions::FindPattern(module, (BYTE*)"\x81\xC6\x38\x03\x00\x00\x83\xC4\x04\x81\xFE", "xxxxxxxxxxx");
     return (*(DWORD*)(result - 10));
 }
@@ -185,6 +178,129 @@ inline LPVOID FindCharacters(void** commFuncs)
 }
 
 /**
+ * @brief Launches POL Core / FFXI and setup Hairpin/Detours.
+ *
+ * @param useHairpinFix Apply Hairpin fix modification.
+ * @param language      POL language.
+ * @param characterList Pointer to character list in memory.
+ * @param sharedState   Shared thread state (bool, mutex, condition_variable).
+ *
+ * @return void.
+ */
+void LaunchFFXI(bool useHairpinFix, const xiloader::Language& language, char*& characterList, xiloader::SharedState& sharedState)
+{
+    /* Initialize COM */
+    auto hResult = CoInitialize(NULL);
+    if (hResult != S_OK && hResult != S_FALSE)
+    {
+        /* Cleanup Winsock */
+        WSACleanup();
+
+        xiloader::console::output(xiloader::color::error, "Failed to initialize COM, error code: %d", hResult);
+        return;
+    }
+
+    /* Attach detour for gethostbyname.. */
+    DetourTransactionBegin();
+    DetourUpdateThread(GetCurrentThread());
+    DetourAttach(&(PVOID&)Real_gethostbyname, Mine_gethostbyname);
+    if (DetourTransactionCommit() != NO_ERROR)
+    {
+        /* Cleanup COM and Winsock */
+        CoUninitialize();
+        WSACleanup();
+
+        xiloader::console::output(xiloader::color::error, "Failed to detour function 'gethostbyname'. Cannot continue!");
+        return;
+    }
+
+    /* Start hairpin hack thread if required.. */
+    std::thread thread_hairpinfix;
+    if (useHairpinFix)
+    {
+        thread_hairpinfix = std::thread(ApplyHairpinFix);
+    }
+
+    /* Attempt to create polcore instance..*/
+    IPOLCoreCom* polcore = NULL;
+    if (CoCreateInstance(xiloader::CLSID_POLCoreCom[language], NULL, 0x17, xiloader::IID_IPOLCoreCom[language], (LPVOID*)&polcore) != S_OK)
+    {
+        xiloader::console::output(xiloader::color::error, "Failed to initialize instance of polcore!");
+    }
+    else
+    {
+        /* Invoke the setup functions for polcore.. */
+        polcore->SetAreaCode(language);
+        polcore->SetParamInit(GetModuleHandle(NULL), " /game eAZcFcB -net 3");
+
+        /* Obtain the common function table.. */
+        void* (**lpCommandTable)(...);
+        polcore->GetCommonFunctionTable((unsigned long**)&lpCommandTable);
+
+        /* Invoke the inet mutex function.. */
+        auto findMutex = (void* (*)(...))FindINETMutex(language);
+        findMutex();
+
+        /* Locate and prepare the pol connection.. */
+        auto polConnection = (char*)FindPolConn(language);
+        memset(polConnection, 0x00, 0x68);
+        auto enc = (char*)malloc(0x1000);
+        memset(enc, 0x00, 0x1000);
+        memcpy(polConnection + 0x48, &enc, sizeof(char**));
+
+        /* Locate the character storage buffer.. */
+        characterList = (char*)FindCharacters((void**)lpCommandTable);
+
+        /* Invoke the setup functions for polcore.. */
+        lpCommandTable[POLFUNC_REGISTRY_LANG](language);
+        lpCommandTable[POLFUNC_FFXI_LANG](xiloader::functions::GetRegistryPlayOnlineLanguage(language));
+        lpCommandTable[POLFUNC_REGISTRY_KEY](xiloader::functions::GetRegistryPlayOnlineKey(language));
+        lpCommandTable[POLFUNC_INSTALL_FOLDER](xiloader::functions::GetRegistryPlayOnlineInstallFolder(language));
+        lpCommandTable[POLFUNC_INET_MUTEX]();
+
+        /* Attempt to create FFXi instance..*/
+        IFFXiEntry* ffxi = NULL;
+        if (CoCreateInstance(xiloader::CLSID_FFXiEntry, NULL, 0x17, xiloader::IID_IFFXiEntry, (LPVOID*)&ffxi) != S_OK)
+        {
+            xiloader::console::output(xiloader::color::error, "Failed to initialize instance of FFxi!");
+        }
+        else
+        {
+            /* Attempt to start Final Fantasy.. */
+            IUnknown* message = NULL;
+            xiloader::console::hide();
+            ffxi->GameStart(polcore, &message);
+            xiloader::console::show();
+            ffxi->Release();
+        }
+
+        /* Cleanup polcore object.. */
+        if (polcore != NULL)
+        {
+            polcore->Release();
+        }
+    }
+
+    if (thread_hairpinfix.joinable())
+    {
+        thread_hairpinfix.join();
+    }
+
+    std::lock_guard<std::mutex> lock(sharedState.mutex);
+    sharedState.isRunning = false;
+    sharedState.conditionVariable.notify_one();
+
+    /* Detach detour for gethostbyname. */
+    DetourTransactionBegin();
+    DetourUpdateThread(GetCurrentThread());
+    DetourDetach(&(PVOID&)Real_gethostbyname, Mine_gethostbyname);
+    DetourTransactionCommit();
+
+    /* Cleanup COM */
+    CoUninitialize();
+}
+
+/**
  * @brief Main program entrypoint.
  *
  * @param argc      The count of arguments being passed to this application on launch.
@@ -195,6 +311,13 @@ inline LPVOID FindCharacters(void** commFuncs)
 int __cdecl main(int argc, char* argv[])
 {
     bool bUseHairpinFix = false;
+    xiloader::Language language = xiloader::Language::English; // The language of the loader to be used for polcore.
+    std::string lobbyServerPort = "51220"; // The server lobby server port.
+    std::string username = ""; // The username being logged in with.
+    std::string password = ""; // The password being logged in with.
+    char* characterList = NULL; // Pointer to the character list data being sent from the server.
+
+    xiloader::SharedState sharedState; // shared thread state
 
     /* Output the banner.. */
     xiloader::console::output(xiloader::color::lightred, "==========================================================");
@@ -213,31 +336,6 @@ int __cdecl main(int argc, char* argv[])
         return 1;
     }
 
-    ///* Initialize COM */
-    //auto hResult = CoInitialize(NULL);
-    //if (hResult != S_OK && hResult != S_FALSE)
-    //{
-    //    /* Cleanup Winsock */
-    //    WSACleanup();
-
-    //    xiloader::console::output(xiloader::color::error, "Failed to initialize COM, error code: %d", hResult);
-    //    return 1;
-    //}
-
-    ///* Attach detour for gethostbyname.. */
-    //DetourTransactionBegin();
-    //DetourUpdateThread(GetCurrentThread());
-    //DetourAttach(&(PVOID&)Real_gethostbyname, Mine_gethostbyname);
-    //if (DetourTransactionCommit() != NO_ERROR)
-    //{
-    //    /* Cleanup COM and Winsock */
-    //    CoUninitialize();
-    //    WSACleanup();
-
-    //    xiloader::console::output(xiloader::color::error, "Failed to detour function 'gethostbyname'. Cannot continue!");
-    //    return 1;
-    //}
-
     /* Read Command Arguments */
     for (auto x = 1; x < argc; ++x)
     {
@@ -251,35 +349,35 @@ int __cdecl main(int argc, char* argv[])
         /* Server Port Argument */
         if (!_strnicmp(argv[x], "--port", 6))
         {
-            g_ServerPort = argv[++x];
+            lobbyServerPort = argv[++x];
             continue;
         }
 
         /* Username Argument */
         if (!_strnicmp(argv[x], "--user", 6))
         {
-            g_Username = argv[++x];
+            username = argv[++x];
             continue;
         }
 
         /* Password Argument */
         if (!_strnicmp(argv[x], "--pass", 6))
         {
-            g_Password = argv[++x];
+            password = argv[++x];
             continue;
         }
 
         /* Language Argument */
         if (!_strnicmp(argv[x], "--lang", 6))
         {
-            std::string language = argv[++x];
+            std::string lang = argv[++x];
 
-            if (!_strnicmp(language.c_str(), "JP", 2) || !_strnicmp(language.c_str(), "0", 1))
-                g_Language = xiloader::Language::Japanese;
-            if (!_strnicmp(language.c_str(), "US", 2) || !_strnicmp(language.c_str(), "1", 1))
-                g_Language = xiloader::Language::English;
-            if (!_strnicmp(language.c_str(), "EU", 2) || !_strnicmp(language.c_str(), "2", 1))
-                g_Language = xiloader::Language::European;
+            if (!_strnicmp(lang.c_str(), "JP", 2) || !_strnicmp(lang.c_str(), "0", 1))
+                language = xiloader::Language::Japanese;
+            if (!_strnicmp(lang.c_str(), "US", 2) || !_strnicmp(lang.c_str(), "1", 1))
+                language = xiloader::Language::English;
+            if (!_strnicmp(lang.c_str(), "EU", 2) || !_strnicmp(lang.c_str(), "2", 1))
+                language = xiloader::Language::European;
 
             continue;
         }
@@ -313,123 +411,22 @@ int __cdecl main(int argc, char* argv[])
         xiloader::datasocket sock;
         SOCKET pol_socket;
         SOCKET pol_clientSocket;
-        if (xiloader::network::CreateConnection(&sock, "54231"))
+        if (xiloader::network::CreateConnection(&sock, g_ServerAddress, "54231"))
         {
             /* Attempt to verify the users account info.. */
-            while (!xiloader::network::VerifyAccount(&sock))
+            while (!xiloader::network::VerifyAccount(&sock, g_ServerAddress, username, password))
             {
                 std::this_thread::sleep_for(std::chrono::milliseconds(10));
             }
 
             /* Create listen servers.. */
-            g_IsRunning = true;
-            std::thread thread_ffxiServer(xiloader::network::FFXiDataComm, &sock);
-            std::thread thead_polServer(xiloader::network::PolServer, std::ref(pol_socket), std::ref(pol_clientSocket));
-            std::thread thread_ffxi([=]() {
-                /* Initialize COM */
-                auto hResult = CoInitialize(NULL);
-                if (hResult != S_OK && hResult != S_FALSE)
-                {
-                    /* Cleanup Winsock */
-                    WSACleanup();
+            sharedState.isRunning = true;
+            std::thread thread_ffxiServer(xiloader::network::FFXiDataComm, &sock, std::cref(g_ServerAddress), std::ref(characterList), std::ref(sharedState));
+            std::thread thead_polServer(xiloader::network::PolServer, std::ref(pol_socket), std::ref(pol_clientSocket), std::cref(lobbyServerPort), std::ref(sharedState));
+            std::thread thread_ffxi(LaunchFFXI, bUseHairpinFix, std::cref(language), std::ref(characterList), std::ref(sharedState));
 
-                    xiloader::console::output(xiloader::color::error, "Failed to initialize COM, error code: %d", hResult);
-                    return;
-                }
-
-                /* Attach detour for gethostbyname.. */
-                DetourTransactionBegin();
-                DetourUpdateThread(GetCurrentThread());
-                DetourAttach(&(PVOID&)Real_gethostbyname, Mine_gethostbyname);
-                if (DetourTransactionCommit() != NO_ERROR)
-                {
-                    /* Cleanup COM and Winsock */
-                    CoUninitialize();
-                    WSACleanup();
-
-                    xiloader::console::output(xiloader::color::error, "Failed to detour function 'gethostbyname'. Cannot continue!");
-                    return;
-                }
-
-                /* Start hairpin hack thread if required.. */
-                std::thread thread_hairpinfix;
-                if (bUseHairpinFix)
-                {
-                    thread_hairpinfix = std::thread(ApplyHairpinFix);
-                }
-
-                /* Attempt to create polcore instance..*/
-                IPOLCoreCom* polcore = NULL;
-                auto co_result = CoCreateInstance(xiloader::CLSID_POLCoreCom[g_Language], NULL, 0x17, xiloader::IID_IPOLCoreCom[g_Language], (LPVOID*)&polcore);
-                if (co_result != S_OK)
-                {
-                    xiloader::console::output(xiloader::color::error, "Failed to initialize instance of polcore!");
-                }
-                else
-                {
-                    /* Invoke the setup functions for polcore.. */
-                    polcore->SetAreaCode(g_Language);
-                    polcore->SetParamInit(GetModuleHandle(NULL), " /game eAZcFcB -net 3");
-
-                    /* Obtain the common function table.. */
-                    void* (**lpCommandTable)(...);
-                    polcore->GetCommonFunctionTable((unsigned long**)&lpCommandTable);
-
-                    /* Invoke the inet mutex function.. */
-                    auto findMutex = (void* (*)(...))FindINETMutex();
-                    findMutex();
-
-                    /* Locate and prepare the pol connection.. */
-                    auto polConnection = (char*)FindPolConn();
-                    memset(polConnection, 0x00, 0x68);
-                    auto enc = (char*)malloc(0x1000);
-                    memset(enc, 0x00, 0x1000);
-                    memcpy(polConnection + 0x48, &enc, sizeof(char**));
-
-                    /* Locate the character storage buffer.. */
-                    g_CharacterList = (char*)FindCharacters((void**)lpCommandTable);
-
-                    /* Invoke the setup functions for polcore.. */
-                    lpCommandTable[POLFUNC_REGISTRY_LANG](g_Language);
-                    lpCommandTable[POLFUNC_FFXI_LANG](xiloader::functions::GetRegistryPlayOnlineLanguage(g_Language));
-                    lpCommandTable[POLFUNC_REGISTRY_KEY](xiloader::functions::GetRegistryPlayOnlineKey(g_Language));
-                    lpCommandTable[POLFUNC_INSTALL_FOLDER](xiloader::functions::GetRegistryPlayOnlineInstallFolder(g_Language));
-                    lpCommandTable[POLFUNC_INET_MUTEX]();
-
-                    /* Attempt to create FFXi instance..*/
-                    IFFXiEntry* ffxi = NULL;
-                    if (CoCreateInstance(xiloader::CLSID_FFXiEntry, NULL, 0x17, xiloader::IID_IFFXiEntry, (LPVOID*)&ffxi) != S_OK)
-                    {
-                        xiloader::console::output(xiloader::color::error, "Failed to initialize instance of FFxi!");
-                    }
-                    else
-                    {
-                        /* Attempt to start Final Fantasy.. */
-                        IUnknown* message = NULL;
-                        xiloader::console::hide();
-                        ffxi->GameStart(polcore, &message);
-                        xiloader::console::show();
-                        ffxi->Release();
-                    }
-
-                    /* Cleanup polcore object.. */
-                    if (polcore != NULL)
-                    {
-                        polcore->Release();
-                    }
-                }
-
-                if (thread_hairpinfix.joinable())
-                {
-                    thread_hairpinfix.join();
-                }
-
-                g_IsRunning = false;
-                g_conditionVariable.notify_one();
-            });
-
-            std::unique_lock<std::mutex> lock(g_mutex);
-            g_conditionVariable.wait(lock, [] { return !g_IsRunning; });
+            std::unique_lock<std::mutex> lock(sharedState.mutex);
+            sharedState.conditionVariable.wait(lock, [&] { return !sharedState.isRunning; });
 
             /* Cleanup sockets.. */
             xiloader::network::CleanupSocket(pol_socket, SD_RECEIVE);
@@ -450,18 +447,10 @@ int __cdecl main(int argc, char* argv[])
         xiloader::console::output(xiloader::color::error, "Failed to resolve server hostname.");
     }
 
-    /* Detach detour for gethostbyname. */
-    DetourTransactionBegin();
-    DetourUpdateThread(GetCurrentThread());
-    DetourDetach(&(PVOID&)Real_gethostbyname, Mine_gethostbyname);
-    DetourTransactionCommit();
-
-    /* Cleanup COM and Winsock */
-    CoUninitialize();
+    /* Cleanup Winsock */
     WSACleanup();
 
     xiloader::console::output(xiloader::color::error, "Closing...");
-    std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 
     return ERROR_SUCCESS;
 }

--- a/xiloader/main.cpp
+++ b/xiloader/main.cpp
@@ -419,7 +419,7 @@ int __cdecl main(int argc, char* argv[])
     WSACleanup();
 
     xiloader::console::output(xiloader::color::error, "Closing...");
-    Sleep(2000);
+    std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 
     return ERROR_SUCCESS;
 }

--- a/xiloader/network.cpp
+++ b/xiloader/network.cpp
@@ -168,7 +168,6 @@ namespace xiloader
         return true;
     }
 
-
     /**
      * @brief Resolves the given hostname to its long ip format.
      *

--- a/xiloader/network.cpp
+++ b/xiloader/network.cpp
@@ -491,8 +491,6 @@ namespace xiloader
             sendSize = 0;
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
-
-        return;
     }
 
     /**
@@ -560,13 +558,6 @@ namespace xiloader
                 break;
 
         } while (result > 0);
-
-        /* Shutdown the client socket.. */
-        if (shutdown(*client, SD_SEND) == SOCKET_ERROR)
-            xiloader::console::output(xiloader::color::error, "Client shutdown failed: %d", WSAGetLastError());
-        closesocket(*client);
-
-        return;
     }
 
     /**
@@ -598,8 +589,9 @@ namespace xiloader
             else
             {
                 /* Start data communication for this client.. */
-                thread_polDataComm = std::thread(xiloader::network::PolDataComm, &client);
-                thread_polDataComm.join();
+                PolDataComm(&client);
+                /* Shutdown the client socket.. */
+                CleanupSocket(client, SD_RECEIVE);
             }
         }
 

--- a/xiloader/network.cpp
+++ b/xiloader/network.cpp
@@ -137,7 +137,7 @@ namespace xiloader
         /* Bind to the local address.. */
         if (bind(*sock, addr->ai_addr, (int)addr->ai_addrlen) == SOCKET_ERROR)
         {
-            xiloader::console::output(xiloader::color::error, "Failed to bind to listening socket.");
+            xiloader::console::output(xiloader::color::error, "Failed to bind to listening socket. %d", WSAGetLastError());
 
             freeaddrinfo(addr);
             closesocket(*sock);
@@ -437,6 +437,7 @@ namespace xiloader
             unsigned int socksize = sizeof(client);
             if (recvfrom(socket->s, recvBuffer, sizeof(recvBuffer), 0, (struct sockaddr*)&client, (int*)&socksize) == SOCKET_ERROR)
             {
+                xiloader::console::output(xiloader::color::error, "Failed recvfrom: %d", WSAGetLastError());
                 xiloader::NotifyShutdown(sharedState);
                 return;
             }
@@ -483,6 +484,7 @@ namespace xiloader
             auto result = sendto(socket->s, sendBuffer, sendSize, 0, (struct sockaddr*)&client, socksize);
             if (sendSize == 72 || result == SOCKET_ERROR || sendSize == -1)
             {
+                xiloader::console::output(xiloader::color::error, "Failed sendto: %d", WSAGetLastError());
                 xiloader::console::output("Server connection done; disconnecting!");
                 xiloader::NotifyShutdown(sharedState);
                 return;
@@ -571,6 +573,7 @@ namespace xiloader
         /* Attempt to create listening server.. */
         if (!xiloader::network::CreateListenServer(&socket, IPPROTO_TCP, lobbyServerPort.c_str()))
         {
+            xiloader::console::output(xiloader::color::error, "Listen failed: %d", WSAGetLastError());
             xiloader::NotifyShutdown(sharedState);
             return;
         }

--- a/xiloader/network.h
+++ b/xiloader/network.h
@@ -35,6 +35,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include <condition_variable>
 
 #include "console.h"
+#include "FFXi.h"
 
 namespace xiloader
 {
@@ -69,10 +70,24 @@ namespace xiloader
      * @brief State shared between operating threads (FFXI, POL, etc).
      */
     typedef struct SharedState {
-        bool isRunning;
+        bool isRunning{ false };
         std::mutex mutex;
         std::condition_variable conditionVariable;
     } SharedState;
+
+    /**
+     * @brief Lock/Signal a system shutdown by modifying running state.
+     *
+     * @param sharedState   Shared thread state (bool, mutex, condition_variable).
+     *
+     * @return void.
+     */
+    static void NotifyShutdown(xiloader::SharedState& sharedState)
+    {
+        std::lock_guard<std::mutex> lock(sharedState.mutex);
+        sharedState.isRunning = false;
+        sharedState.conditionVariable.notify_all();
+    }
 
     /**
      * @brief Network class containing functions related to networking.

--- a/xiloader/network.h
+++ b/xiloader/network.h
@@ -84,9 +84,12 @@ namespace xiloader
      */
     static void NotifyShutdown(xiloader::SharedState& sharedState)
     {
-        std::lock_guard<std::mutex> lock(sharedState.mutex);
-        sharedState.isRunning = false;
-        sharedState.conditionVariable.notify_all();
+        if (sharedState.isRunning)
+        { 
+            std::lock_guard<std::mutex> lock(sharedState.mutex);
+            sharedState.isRunning = false;
+            sharedState.conditionVariable.notify_all();
+        }
     }
 
     /**
@@ -101,7 +104,7 @@ namespace xiloader
          *
          * @return void.
          */
-        static void PolDataComm(SOCKET* client);
+        static void PolDataComm(SOCKET* client, xiloader::SharedState& sharedState);
         
     public:
 

--- a/xiloader/network.h
+++ b/xiloader/network.h
@@ -131,21 +131,22 @@ namespace xiloader
         /**
          * @brief Starts the local listen server to lobby server communications.
          *
-         * @param lpParam       Thread param object.
+         * @param socket        Socket reference.
+         * @param client        Client Socket reference.
          *
-         * @return Non-important return.
+         * @return void.
          */
-        static DWORD __stdcall PolServer(LPVOID lpParam);
+        static void PolServer(SOCKET& socket, SOCKET& client);
 
         /**
          * @brief Cleans up a socket via shutdown/close.
          *
-         * @param socket        Pointer to datasocket containing socket address.
+         * @param socket        Socket reference.
          * @param how           Shutdown send, recv, or both.
          *
          * @return void.
          */
-        static void CleanupSocket(xiloader::datasocket* socket, int how);
+        static void CleanupSocket(SOCKET& socket, int how);
     };
 
 }; // namespace xiloader

--- a/xiloader/network.h
+++ b/xiloader/network.h
@@ -71,11 +71,11 @@ namespace xiloader
         /**
          * @brief Data communication between the local client and the lobby server.
          *
-         * @param lpParam       Thread param object.
+         * @param client        Pointer to Socket.
          *
-         * @return Non-important return.
+         * @return void.
          */
-        static DWORD __stdcall PolDataComm(LPVOID lpParam);
+        static void PolDataComm(SOCKET* client);
         
     public:
 

--- a/xiloader/network.h
+++ b/xiloader/network.h
@@ -69,15 +69,6 @@ namespace xiloader
     class network
     {
         /**
-         * @brief Data communication between the local client and the game server.
-         *
-         * @param lpParam       Thread param object.
-         *
-         * @return Non-important return.
-         */
-        static DWORD __stdcall FFXiDataComm(LPVOID lpParam);
-
-        /**
          * @brief Data communication between the local client and the lobby server.
          *
          * @param lpParam       Thread param object.
@@ -87,6 +78,15 @@ namespace xiloader
         static DWORD __stdcall PolDataComm(LPVOID lpParam);
         
     public:
+
+        /**
+         * @brief Data communication between the local client and the game server.
+         *
+         * @param socket        Pointer to communication socket.
+         *
+         * @return void.
+         */
+        static void FFXiDataComm(xiloader::datasocket* socket);
 
         /**
          * @brief Creates a connection on the given port.
@@ -127,15 +127,6 @@ namespace xiloader
          * @return True on success, false otherwise.
          */
         static bool VerifyAccount(datasocket* sock);
-        
-        /**
-         * @brief Starts the data communication between the client and server.
-         *
-         * @param lpParam       Thread param object.
-         *
-         * @return Non-important return.
-         */
-        static DWORD __stdcall FFXiServer(LPVOID lpParam);
 
         /**
          * @brief Starts the local listen server to lobby server communications.
@@ -145,6 +136,16 @@ namespace xiloader
          * @return Non-important return.
          */
         static DWORD __stdcall PolServer(LPVOID lpParam);
+
+        /**
+         * @brief Cleans up a socket via shutdown/close.
+         *
+         * @param socket        Pointer to datasocket containing socket address.
+         * @param how           Shutdown send, recv, or both.
+         *
+         * @return void.
+         */
+        static void CleanupSocket(xiloader::datasocket* socket, int how);
     };
 
 }; // namespace xiloader


### PR DESCRIPTION
This is a collection of updates to move away from Win32 thread calls and provide more handling around errors found in other threads not causing Xiloader to exit.

- CreateThread -> std::thread
- Collapsed some thread spawning (FFXI Server -> FFXIDataComm, PolServer -> spawn PolDataComm)
- Exit FFXI thread last
- Update generic sleep calls - we may be able to turn these sleep calls into yield
- Provide signaling via shared state (mutex, condition_variable)
- Move FFXI into separate launch thread from main(...)
- main(...) waits for threads triggering a shutdown
- Socket cleanup logic
- Move global variables to local/passed to functions

Tested against local topaz servers and a few remote (Canaria, etc).

Below is a sample exit:

![image](https://user-images.githubusercontent.com/1033099/83978754-73e71c80-a8be-11ea-9aef-8dfa60dc532e.png)

Accept Failed is triggered when xiloader closes up communication sockets during shutdown.  If we do not close the sockets xiloader will hang on looking for connections or receiving data.