### PR TITLE
Set internal socket to be reusable to support multiboxing

### DIFF
--- a/xiloader/network.cpp
+++ b/xiloader/network.cpp
@@ -134,6 +134,15 @@ namespace xiloader
             return false;
         }
 
+        /* Set socket option on internal server to allow sharing the port for multibox users */
+        if (setsockopt(*sock, SOL_SOCKET, SO_REUSEADDR, (char*)(&[] { return TRUE; }), sizeof(BOOL)) == SOCKET_ERROR)
+        {
+            xiloader::console::output(xiloader::color::error, "Failed to set reusable address option on socket. %d", WSAGetLastError());
+
+            freeaddrinfo(addr);
+            return false;
+        }
+
         /* Bind to the local address.. */
         if (bind(*sock, addr->ai_addr, (int)addr->ai_addrlen) == SOCKET_ERROR)
         {


### PR DESCRIPTION
This causes the internal server used by the loader to allow multiple bindings to the same address/port pair which allows for multiple clients to be run in parallel.

In theory, setsockopt before bind should never cause an error, rather instead causing an error to be raised on bind, but its better to have the error check than not.