### PR TITLE
Resolves character selection issues in various content ID slots

### DIFF
--- a/xiloader/network.cpp
+++ b/xiloader/network.cpp
@@ -479,7 +479,7 @@ namespace xiloader
                     characterList[0x18 + (x * 0x68)] = 0x20;
                     characterList[0x28 + (x * 0x68)] = 0x20;
 
-                    memcpy(characterList + 0x04 + (x * 0x68), recvBuffer + 0x14 * (x + 1), 4); // Character Id
+                    memcpy(characterList + 0x04 + (x * 0x68), recvBuffer + (0x10 * (x + 1)) + 0x04, 4); // Character Id
                     memcpy(characterList + 0x08 + (x * 0x68), recvBuffer + 0x10 * (x + 1), 4); // Content Id
                 }
                 sendSize = 0;


### PR DESCRIPTION
This fix was provided to me by Cygon, with the following description:

> Resolves an issue selecting characters in various content ID slots at the character select screen (easiest test is against slot 4)

Related Issue: https://github.com/project-topaz/topaz/issues/2